### PR TITLE
add delegate check to approve + fix warnings

### DIFF
--- a/programs/asset_controller/src/instructions/enforce/approve.rs
+++ b/programs/asset_controller/src/instructions/enforce/approve.rs
@@ -16,6 +16,7 @@ pub struct ApproveTransaction<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
     /// CHECK: constraint checks
+    #[account(constraint = signer.key() == asset_controller.delegate)]
     pub signer: UncheckedAccount<'info>,
     #[account(
         mint::token_program = TOKEN22
@@ -29,6 +30,11 @@ pub struct ApproveTransaction<'info> {
         bump,
     )]
     pub transaction_approval_account: Box<Account<'info, TransactionApprovalAccount>>,
+    #[account(
+        seeds = [asset_mint.key().as_ref()],
+        bump,
+    )]
+    pub asset_controller: Box<Account<'info, AssetControllerAccount>>,
     pub system_program: Program<'info, System>,
 }
 

--- a/programs/asset_controller/src/instructions/token/void.rs
+++ b/programs/asset_controller/src/instructions/token/void.rs
@@ -1,8 +1,5 @@
 use anchor_lang::{prelude::*, solana_program::program_option::COption};
-use anchor_spl::{
-    associated_token::AssociatedToken,
-    token_interface::{burn, Burn, Mint, Token2022, TokenAccount},
-};
+use anchor_spl::token_interface::{burn, Burn, Mint, Token2022, TokenAccount};
 
 use crate::TransactionApprovalAccount;
 

--- a/programs/asset_controller/src/instructions/transfer.rs
+++ b/programs/asset_controller/src/instructions/transfer.rs
@@ -22,7 +22,7 @@ pub struct TransferTokens<'info> {
     )]
     pub asset_mint: Box<InterfaceAccount<'info, Mint>>,
     #[account(
-        init,
+        init_if_needed,
         payer = payer,
         space = TransactionApprovalAccount::LEN,
         seeds = [TransactionApprovalAccount::SEED.as_ref(), asset_mint.key().as_ref()],

--- a/programs/identity_registry/src/instructions/account/add.rs
+++ b/programs/identity_registry/src/instructions/account/add.rs
@@ -24,7 +24,7 @@ pub struct AddLevelIdentityAccount<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn handler(ctx: Context<AddLevelIdentityAccount>, owner: Pubkey, level: u8) -> Result<()> {
+pub fn handler(ctx: Context<AddLevelIdentityAccount>, _owner: Pubkey, level: u8) -> Result<()> {
     // confirm signer is either authority or signer
     ctx.accounts
         .identity_registry

--- a/programs/identity_registry/src/instructions/account/remove.rs
+++ b/programs/identity_registry/src/instructions/account/remove.rs
@@ -24,7 +24,7 @@ pub struct RemoveLevelIdentityAccount<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn handler(ctx: Context<RemoveLevelIdentityAccount>, owner: Pubkey, level: u8) -> Result<()> {
+pub fn handler(ctx: Context<RemoveLevelIdentityAccount>, _owner: Pubkey, level: u8) -> Result<()> {
     // confirm signer is either authority or signer
     ctx.accounts
         .identity_registry

--- a/programs/identity_registry/src/instructions/account/revoke.rs
+++ b/programs/identity_registry/src/instructions/account/revoke.rs
@@ -24,7 +24,7 @@ pub struct RevokeIdentityAccount<'info> {
     pub identity_account: Box<Account<'info, IdentityAccount>>,
 }
 
-pub fn handler(ctx: Context<RevokeIdentityAccount>, owner: Pubkey) -> Result<()> {
+pub fn handler(ctx: Context<RevokeIdentityAccount>, _owner: Pubkey) -> Result<()> {
     // confirm signer is either authority or signer
     ctx.accounts
         .identity_registry


### PR DESCRIPTION
Add a delegate check to prevent errant calls to approve. Update transfer to use init_if_needed to work in conjunction with approve. This will make it so that if someone wants to use external policies, they can call approve with their custom policy engine as a delegate, and then call transfer.